### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Printrbot SKR Adaptrboard 
-#### 32bit Motion Controller adapter kit
+## 32bit Motion Controller adapter kit
+
+<a href="https://github.com/MachX428/Adaptrboard/wiki"><img src="https://raw.githubusercontent.com/wiki/MachX428/Adaptrboard/images/adaptrboard_float.png" width="500"></a> 
+
+### [Click Here for Installation Instructions](https://github.com/MachX428/Adaptrboard/wiki)
+
+
+#### More Info
 
 Plug and Play controller wiring harness 
 	 Replacement kit for Printrboard
@@ -7,9 +14,9 @@ Plug and Play controller wiring harness
 	 
 
 
-	Marlin firmware for 32bit SKR control boards
+#### Marlin firmware for 32bit SKR control boards
 
-#### Precompiled Firmware- Semi Tested - Download Repo as Zip file
+##### Precompiled Firmware- Semi Tested - Download Repo as Zip file
   Metal Plus - Single Extruder - TMC2208
   
   Metal Plus - Dual Extruder - TMC2130 XYZ - A4988 E1 E2


### PR DESCRIPTION
Added a link on the README.md to installation instructions, which are currently residing on the MachX428/Adaptrboard fork wiki.